### PR TITLE
Add componentDidCatch to exclude list (React 16)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,15 +28,13 @@ const reactAutoBind = (self, ...bindOnly) => {
 	});
 
 	return self;
-}
+};
 
 if (typeof module !== 'undefined' && module.exports) {
 	module.exports = reactAutoBind;
 } else if (typeof define === 'function' && define.amd) {
 	// Register as 'react-auto-bind', consistent with npm package name
-	define('react-auto-bind', [], function () {
-		return reactAutoBind;
-	});
+	define('react-auto-bind', [], () => reactAutoBind);
 } else {
 	window.reactAutoBind = reactAutoBind;
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var exclude = [
+const exclude = [
 	'render',
 	'componentWillReceiveProps',
 	'componentDidMount',
@@ -17,7 +17,7 @@ var exclude = [
 
 function reactAutoBind(self, ...bindOnly) {
 	((bindOnly.length && bindOnly) || Object.getOwnPropertyNames(self.constructor.prototype))
-	.forEach(function (key) {
+	.forEach((key) => {
 		const val = self[key];
 
 		if (key !== 'constructor' && typeof val === 'function') {
@@ -33,7 +33,7 @@ function reactAutoBind(self, ...bindOnly) {
 if (typeof module !== 'undefined' && module.exports) {
 	module.exports = reactAutoBind;
 } else if (typeof define === 'function' && define.amd) {
-	// register as 'react-auto-bind', consistent with npm package name
+	// Register as 'react-auto-bind', consistent with npm package name
 	define('react-auto-bind', [], function () {
 		return reactAutoBind;
 	});

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var exclude = [
 	'componentWillReceiveProps',
 	'componentDidMount',
 	'componentDidUpdate',
+	'componentDidCatch',
 	'shouldComponentUpdate',
 	'componentWillUnmount',
 	'componentWillUpdate',

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ const exclude = [
 	'componentWillMount'
 ];
 
-function reactAutoBind(self, ...bindOnly) {
+const reactAutoBind = (self, ...bindOnly) => {
 	((bindOnly.length && bindOnly) || Object.getOwnPropertyNames(self.constructor.prototype))
-	.forEach((key) => {
+	.forEach(key => {
 		const val = self[key];
 
 		if (key !== 'constructor' && typeof val === 'function') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-auto-bind",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Auto bind methods to their class instance excluding React Lifecycle Methods",
   "license": "MIT",
   "repository": "housinghq/react-auto-bind",


### PR DESCRIPTION
React 16 introduces new life cycle method `componentDidCatch` which should be excluded while auto-binding.